### PR TITLE
Fix websocket state callback

### DIFF
--- a/custom_components/ryobi_gdo/api.py
+++ b/custom_components/ryobi_gdo/api.py
@@ -362,6 +362,8 @@ class RyobiApiClient:
             # STATE_STOPPED with no error
             else:
                 LOGGER.debug("Websocket state: %s error: %s", msg, error)
+            if self.callback is not None:
+                await self.callback()
 
         elif msg_type == "data":
             message = msg
@@ -502,7 +504,7 @@ class RyobiWebSocket:
                 self.url,
                 heartbeat=15,
                 headers=header,
-                receive_timeout=5*60, #Should see something from Ryobi about every 5 Minutes
+                receive_timeout=5 * 60,  # Should see something from Ryobi about every 5 minutes
             ) as ws_client:
                 self._ws_client = ws_client
 


### PR DESCRIPTION
## Summary
- fire websocket callback on state changes
- fix whitespace in a timeout comment

## Testing
- `flake8`
- `pytest -q` *(fails: ModuleNotFoundError / AttributeError)*

------
https://chatgpt.com/codex/tasks/task_e_6846041e096c83249e83bc974ac603a7