### PR TITLE
Fix websocket async connection

### DIFF
--- a/custom_components/ryobi_gdo/__init__.py
+++ b/custom_components/ryobi_gdo/__init__.py
@@ -42,7 +42,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         raise ConfigEntryNotReady
 
     # Start websocket listener
-    coordinator.client.ws_connect()
+    await coordinator.client.ws_connect()
 
     hass.data[DOMAIN][config_entry.entry_id] = {COORDINATOR: coordinator}
 

--- a/custom_components/ryobi_gdo/coordinator.py
+++ b/custom_components/ryobi_gdo/coordinator.py
@@ -57,7 +57,7 @@ class RyobiDataUpdateCoordinator(DataUpdateCoordinator):
         """Handle reconnection of websocket."""
         if not self.client.ws_listening:
             # Reconnect the websocket
-            self.client.ws_connect()
+            await self.client.ws_connect()
 
     @callback
     async def websocket_update(self):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
 # pylint: disable=protected-access,redefined-outer-name
 """Global fixtures for integration."""
 import os
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 from aioresponses import aioresponses
 import pytest
@@ -78,7 +78,8 @@ def mock_device(mock_aioclient):
 async def mock_ws(mock_aioclient):
     """Mock API call for API key endpoint."""
     with patch(
-        "custom_components.ryobi_gdo.api.RyobiApiClient.ws_connect"
+        "custom_components.ryobi_gdo.api.RyobiApiClient.ws_connect",
+        new_callable=AsyncMock,
     ) as mock_value:
         mock_value.return_value = True
         yield
@@ -88,7 +89,8 @@ async def mock_ws(mock_aioclient):
 def mock_ws_start():
     """Mock charger fw data."""
     with patch(
-        "custom_components.ryobi_gdo.api.RyobiApiClient.ws_connect"
+        "custom_components.ryobi_gdo.api.RyobiApiClient.ws_connect",
+        new_callable=AsyncMock,
     ) as mock_value:
         mock_value.return_value = True
         yield mock_value


### PR DESCRIPTION
## Summary
- fix websocket reconnection to use async calls
- patch tests for async ws_connect

## Testing
- `flake8 custom_components/ryobi_gdo tests`
- `pytest -q` *(fails: AttributeError: 'async_generator' object has no attribute 'data')*

------
https://chatgpt.com/codex/tasks/task_e_684655d164a8832491e5a21d535b3c74