### PR TITLE
Fix awaited config entry setup

### DIFF
--- a/custom_components/ryobi_gdo/__init__.py
+++ b/custom_components/ryobi_gdo/__init__.py
@@ -46,10 +46,12 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
 
     hass.data[DOMAIN][config_entry.entry_id] = {COORDINATOR: coordinator}
 
-    for platform in PLATFORMS:
-        hass.async_create_task(
+    await asyncio.gather(
+        *(
             hass.config_entries.async_forward_entry_setup(config_entry, platform)
+            for platform in PLATFORMS
         )
+    )
 
     return True
 


### PR DESCRIPTION
## Summary
- fix forward entry setup to be awaited

## Testing
- `ruff check custom_components/ryobi_gdo/__init__.py`
- `pytest -q` *(fails: AttributeError: 'async_generator' object has no attribute 'data')*

------
https://chatgpt.com/codex/tasks/task_e_6847a12cb3a48324a47c86e9a3cb6949